### PR TITLE
Contract update

### DIFF
--- a/src/contracts/dCheque.sol
+++ b/src/contracts/dCheque.sol
@@ -12,66 +12,55 @@ contract dCheque {
         bool voided;
         bool transferable;
     }
-    // Need to give array of approved addresses for merchant and auditor
-    mapping(address=>mapping(address=>bool)) public merchantAuditor;  // Merchent=>Auditor
-    mapping(address=>uint256) public acceptedMerchantAuditorCount;  // Merchent=>Auditor
+    mapping(address=>mapping(address=>bool)) public userAuditor;  // Whether User accepts Auditor
+    mapping(address=>address[]) public acceptedUserAuditors;  // Auditor addresses that users accept
+    mapping(address=>mapping(address=>bool)) public auditorUser;  // Whether Auditor accepts User
+    mapping(address=>address[]) public acceptedAuditorUsers;  // User addresses that auditors accept
+    mapping(address=>mapping(uint256=>bool)) public auditorDurations;  // Auditor voiding periods
 
-    mapping(address=>mapping(address=>bool)) public signerAuditor;  // Signer=>Auditor
-    mapping(address=>address[]) public signerAuditorArray;  // Signer=>Auditor
-
-    // mapping(address=>mapping(uint256=>bool)) public auditorDurations;  // Auditor
     mapping(uint256=>Cheque) public cheques;
-    mapping(address=>uint256) public chequeCount;
+    mapping(address=>uint256) public chequeCount;  // User's balance of cheques
+    mapping(address=>uint256) public deposits;  // Total user deposits
+    uint256 private totalSupply;  // Total cheques created
+
     mapping(address=>address) public trustedAccount;  // User's trusted account
     mapping(address=>uint256) public lastTrustedChange;
-    mapping(address=>uint256) public deposits;
-
-    uint256 private totalSupply;
-    uint256 private trustedAccountCooldown;
-    uint256 private transferFee;
+    uint256 private trustedAccountCooldown = 180 days;
 
     event Deposit(address indexed from, uint256 amount);
-    event Transfer(address indexed from, address indexed to);
-    event Void(address indexed drawer, address indexed auditor, uint256 indexed chequeId);
-    event Cash(address indexed bearer, uint256 indexed chequeId);
-    event acceptAuditor(address indexed merchant, address indexed auditor);
-    event acceptUser(address indexed auditor, address indexed user);
-
-    constructor(){
-        trustedAccountCooldown = 180;
-        transferFee = 250;
-    }
+    event Transfer(address indexed from, address indexed to, uint256 indexed chequeID);
+    event Void(address indexed drawer, address indexed auditor, uint256 indexed chequeID);
+    event Cash(address indexed bearer, uint256 indexed chequeID);
+    event AcceptAuditor(address indexed user, address indexed auditor);
+    event AcceptUser(address indexed auditor, address indexed user);
 
     receive() external payable{
         emit Deposit(msg.sender, msg.value);
         deposits[msg.sender] += msg.value;
     }
-    function ownerOf(uint256 chequeId) external view returns(address) {
-        return cheques[chequeId].bearer;
-    }
     function writeCheque(uint256 amount, uint256 duration, address auditor) public {
         require(deposits[msg.sender]>=amount, "Writing more than available");
-        require(auditor!=address(0), "Auditor null address");
-        // require(auditorDurations[auditor][duration], "Auditor doesn't allow this duration");
-        require(signerAuditor[msg.sender][auditor], "Auditor must approve this account");
+        require(userAuditor[msg.sender][auditor], "User must approve this auditor");
+        require(auditorUser[auditor][msg.sender],  "Auditor must approve this account");
+        require(auditorDurations[auditor][duration], "Auditor doesn't allow this duration");
         deposits[msg.sender] -= amount;
         totalSupply += 1;
         chequeCount[msg.sender]+=1;
-        cheques[totalSupply+1] = Cheque({drawer: msg.sender, bearer: msg.sender, expiry: block.timestamp+duration, 
+        cheques[totalSupply] = Cheque({drawer: msg.sender, bearer: msg.sender, expiry: block.timestamp+duration, 
                                          auditor: auditor, amount: amount, voided: false, transferable: true});
-        emit Transfer(msg.sender, msg.sender);
+        emit Transfer(address(0), msg.sender, totalSupply);
     }
     function writeCheque(uint256 amount, uint256 duration, address auditor, address to) public {
         require(deposits[msg.sender]>=amount, "Writing more than available");
-        // require(auditorDurations[auditor][duration], "Auditor doesn't allow this duration");
-        require(signerAuditor[msg.sender][auditor], "Auditor must approve this account");
-        require(merchantAuditor[msg.sender][auditor], "Merchant doesn't accept this auditor");
+        require(userAuditor[msg.sender][auditor], "User must approve this auditor");
+        require(auditorUser[auditor][msg.sender],  "Auditor must approve this account");
+        require(auditorDurations[auditor][duration], "Auditor doesn't allow this duration");
         deposits[msg.sender] -= amount;
         totalSupply += 1;
         chequeCount[to]+=1;
-        cheques[totalSupply+1] = Cheque({drawer: msg.sender, bearer: to, expiry: block.timestamp+duration, 
-                                       auditor: auditor, amount:amount, voided:false, transferable:true});
-        emit Transfer(msg.sender, to);
+        cheques[totalSupply] = Cheque({drawer: msg.sender, bearer: to, expiry: block.timestamp+duration, 
+                                         auditor: auditor, amount: amount, voided: false, transferable: true});
+        emit Transfer(msg.sender, to, totalSupply);
     }
     function cashCheque(uint256 chequeID) external {  // Only allow withdraws via cheque writing
         Cheque storage cheque = cheques[chequeID];
@@ -89,6 +78,7 @@ contract dCheque {
         require(cheque.auditor==msg.sender, "Must be auditor");
         require(cheque.expiry<block.timestamp, "Cheque already matured");
         cheque.voided = true;
+        cheque.transferable = false;
         chequeCount[cheque.bearer]-=1;
         deposits[cheque.drawer] += cheque.amount;  // Add balance back to signer
         emit Void(cheque.drawer, cheque.auditor, chequeID);
@@ -98,45 +88,68 @@ contract dCheque {
         require(cheque.auditor==msg.sender, "Must be auditor");
         require(cheque.expiry<block.timestamp, "Cheque already matured");
         cheque.voided = true;
+        cheque.transferable = false;
         chequeCount[cheque.bearer]-=1;
-        deposits[trustedAccount[cheque.drawer]] += cheque.amount;  // Add balance back to trusted (secondary) account
+        address fallbackAccount = trustedAccount[cheque.drawer];
+        deposits[fallbackAccount] += cheque.amount;  // Add cheque amount to trusted account deposit balance
         emit Void(cheque.drawer, cheque.auditor, chequeID);
+        emit Transfer(cheque.bearer, fallbackAccount, chequeID);
     }
     function transfer(address to, uint256 chequeID) external {
         Cheque storage cheque = cheques[chequeID];
         require(cheque.bearer==msg.sender, "Only cheque owner can transfer");
-        require(cheque.transferable && (!cheque.voided), "Cheque not transferable");
+        require(cheque.transferable, "Cheque not transferable");
         cheque.bearer = to;
-        emit Transfer(msg.sender, to);
+        emit Transfer(msg.sender, to, chequeID);
     }
-    function setmerchantAuditor(address auditor) external {  // Merchant will set this
-        merchantAuditor[msg.sender][auditor] = true;
+
+    function acceptAuditor(address auditor) public returns (bool){  // Initiate handshake: User will set this
+        userAuditor[msg.sender][auditor] = true;
+        emit AcceptAuditor(msg.sender, auditor);
+        return true;
     }
-    function getChequeAuditor(uint256 chequeId) external view returns (address) {
-        return cheques[chequeId].auditor;
-    } 
-    // function setAllowedDuration(uint256 duration) external {  // Auditor will set this
-    //     auditorDurations[msg.sender][duration] = true;
-    // }
-    function setAcceptedDrawers(address signer) external {  // Auditor will set this
-        signerAuditor[msg.sender][signer] = true;
+    function acceptUser(address drawer) public returns (bool){  // Initiate handshake: Auditor will set this
+        auditorUser[msg.sender][drawer] = true;
+        emit AcceptUser(msg.sender, drawer);
+        return true;
+    }
+    function acceptAddAuditor(address auditor) external{  // Finish handshake: add the auditor to the user's list
+        require(userAuditor[msg.sender][auditor], "Auditor must accept you to be added to your auditor list");
+        require(acceptAuditor(auditor), "");
+        acceptedUserAuditors[msg.sender].push(auditor);
+        acceptedAuditorUsers[auditor].push(msg.sender);
+    }
+    function acceptAddUser(address user) external{ // Finish handshake: add the user to the auditor's list
+        require(auditorUser[msg.sender][user], "User must accept you to be added to your user list");
+        require(acceptUser(user), "");
+        acceptedAuditorUsers[msg.sender].push(user);
+        acceptedUserAuditors[user].push(msg.sender);
+    }
+
+    function setAllowedDuration(uint256 duration) external {  // Auditor will set this
+        auditorDurations[msg.sender][duration] = true;
     }
     function setTrustedAccount(address account) external {
-        require((lastTrustedChange[msg.sender] + 180 days)<block.timestamp, "Can only change trusted account once every 180 days");
+        require((lastTrustedChange[msg.sender] + trustedAccountCooldown)<block.timestamp, "Can only change trusted account once every 180 days");
         trustedAccount[msg.sender] = account;
-        lastTrustedChange[msg.sender] += block.timestamp;
+        lastTrustedChange[msg.sender] = block.timestamp;
     }
-    function getChequeDrawer(uint256 chequeId) external view returns (address) {
+
+
+    function chequeDrawer(uint256 chequeId) external view returns (address) {
         return cheques[chequeId].drawer;
     }
-    function getChequeBearer(uint256 chequeId) external view returns (address) {
+    function ownerOf(uint256 chequeId) external view returns(address) {
         return cheques[chequeId].bearer;
+    }
+    function chequeAuditor(uint256 chequeId) external view returns (address) {
+        return cheques[chequeId].auditor;
+    } 
+    function chequeAmount(uint256 chequeId) external view returns (uint256) {
+        return cheques[chequeId].amount;
     }
     function chequeExpiry(uint256 chequeId) external view returns (uint256) {
         return cheques[chequeId].expiry;
-    }
-    function chequeAmount(uint256 chequeId) external view returns (uint256) {
-        return cheques[chequeId].amount;
     }
     function chequeVoided(uint256 chequeId) external view returns (bool) {
         return cheques[chequeId].voided;


### PR DESCRIPTION
Simplified user-auditor model (from user-auditor-merchant), enable user-auditor handshake, save hand-shaken addresses for users/auditors (can be offloaded to front-end services like graphQL via events instead) to allow drop-downs of auditors when sending cheques, add more events, prevent confusion/exploit of cheques via transfers vs writing to intended recipient by adding the unchanging recipient field in the cheque struct