### PR TITLE
Fix confirm address overflow on mobile

### DIFF
--- a/src/components/designSystem/DetailsRow.tsx
+++ b/src/components/designSystem/DetailsRow.tsx
@@ -22,13 +22,7 @@ function DetailsRow({ title, value, link }: Props) {
           {title}
         </Text>
         <HStack minWidth={0} pl={4}>
-          <Text
-            fontWeight={200}
-            fontSize="md"
-            textAlign="center"
-            maxW="100%"
-            noOfLines={1}
-          >
+          <Text fontWeight={200} fontSize="md" textAlign="right" noOfLines={1}>
             {value}
           </Text>
           {link && (


### PR DESCRIPTION
Before:
<img width="398" alt="Screenshot 2023-02-09 at 9 34 00 PM" src="https://user-images.githubusercontent.com/10327933/217994667-d7868f8c-30c9-42f8-b4e0-148e76f02771.png">


After:
<img width="402" alt="Screenshot 2023-02-09 at 9 29 26 PM" src="https://user-images.githubusercontent.com/10327933/217994627-68f00cbe-811e-43e8-890c-b9bf9344a9f2.png">
